### PR TITLE
Scrollable container as property via querySelector

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,13 +43,18 @@ export default class ScrollViewport extends Component {
 	componentDidMount() {
 		this.resized();
 		this.scrolled();
+
+		let scrollEventHolder = (this.props.scroll) ? document.querySelector(this.props.scroll) : window;
+
 		addEventListener('resize', this.resized, EVENT_OPTS);
-		addEventListener('scroll', this.scrolled, EVENT_OPTS);
+		scrollEventHolder.addEventListener('scroll', this.scrolled, EVENT_OPTS);
 	}
 
 	componentWillUnmount() {
+		let scrollEventHolder = (this.props.scroll) ? document.querySelector(this.props.scroll) : window;
+
 		removeEventListener('resize', this.resized, EVENT_OPTS);
-		removeEventListener('scroll', this.scrolled, EVENT_OPTS);
+		scrollEventHolder.removeEventListener('scroll', this.scrolled, EVENT_OPTS);
 	}
 
 	render({ overscan=10, rowHeight, defaultRowHeight, children, ...props }, { offset=0, height=0 }) {


### PR DESCRIPTION
Hello, I had problems using this component inside a panel that had overflow set to scroll or auto. I made it so that I could pass in the panel's selector as "scroll" property to then bind the scroll event listener to.
Using window smells a bit iffy but works for my use case. Happy to discuss?