### PR TITLE
Fix scroll events inside wrappers of fixed height

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 import { h, Component } from 'preact';
 
 const EVENT_OPTS = {
-	passive: true
+	passive: true,
+	capture: true
 };
 
 /** Virtual list, renders only visible items.


### PR DESCRIPTION
Hey, thanks for your work, loving preact. :)

Noticed this component doesn't work for a list I have in a dialog box. I can reproduce the issue with this markup:

``` html
<div style="max-height: 400px; border: 1px dashed; padding: 30px; overflow: scroll;">
	<div style="height: 10000px;"></div>
</div>

<script>
	window.addEventListener('scroll', () => console.log('scrolled'), false)
</script>
```

The scroll event doesn't fire on window. Enabling the event capture phase fixes it.